### PR TITLE
Add data-height and data-width attributes

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -322,6 +322,11 @@ function easy_image_gallery() {
 
 			// get original image
 			$image_link	= wp_get_attachment_image_src( $attachment_id, apply_filters( 'easy_image_gallery_linked_image_size', 'large' ) );
+			
+			// set image dimensions for anchor tag attribute
+			$image_width	=	$image_link[1];
+			$image_height	=	$image_link[2];
+			
 			$image_link	= $image_link[0];	
 
 			$image = wp_get_attachment_image( $attachment_id, apply_filters( 'easy_image_gallery_thumbnail_image_size', 'thumbnail' ), '', array( 'alt' => trim( strip_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) ) ) );
@@ -335,7 +340,7 @@ function easy_image_gallery() {
 			$rel = easy_image_gallery_count_images() > 1 ? 'rel="'. $lightbox .'[group]"' : 'rel="'. $lightbox .'"';
 
 			if ( easy_image_gallery_has_linked_images() )
-				$html = sprintf( '<li><a %s href="%s" class="%s" title="%s"><i class="icon-view"></i><span class="overlay"></span>%s</a></li>', $rel, $image_link, $image_class, $image_caption, $image );
+				$html = sprintf( '<li><a %s href="%s" class="%s" title="%s" data-width="%s" data-height="%s"><i class="icon-view"></i><span class="overlay"></span>%s</a></li>', $rel, $image_link, $image_class, $image_caption, $image_width, $image_height, $image );
 			else
 				$html = sprintf( '<li>%s</li>', $image );
 


### PR DESCRIPTION
Grab the image height and width already returned by
wp_get_attachment_image_src() and set them on the <a> tag of the
gallery image markup. Having height and width explicitly specified is required for Photoswipe image viewer.